### PR TITLE
Made lidar more realistic

### DIFF
--- a/constants.h
+++ b/constants.h
@@ -10,13 +10,17 @@ const double ROBOT_LENGTH = 1.0; // m
 const double ROBOT_WHEEL_BASE = ROBOT_LENGTH*2/3; // m
 const double MAX_SPEED = ROBOT_LENGTH * 10; // m/s
 
+const double OBSTACLE_MAX_SIZE = ROBOT_LENGTH * 15; // m. used for efficient calculations
+
 /* Sensors and actuators */
 // I define a lot of these constants in terms of ROBOT_LENGTH to make it easy to change the scale
 
 const double LANDMARK_MAX_RANGE = ROBOT_LENGTH * 15; // m
-const double LIDAR_MAX_RANGE = ROBOT_LENGTH * 15; // m
+const double LIDAR_MAX_RANGE = ROBOT_LENGTH * 5.6; // m
 const double LIDAR_MIN_RANGE = ROBOT_LENGTH; // m
-const int LIDAR_RESOLUTION = 100; // number of scans per full rotation
+const int LIDAR_RESOLUTION = 100; // number of scans in the lidar fov
+const double LIDAR_FOV = 240.0 * M_PI / 180.0; // rad
+const double LIDAR_FOV_DIR = 0; // radians, gives the direction relative to robot front of fov center
 const double CORRUPTION_STD = 0.04; // std in meters at 1 meter distance
                                     // variance increases for measurements farther from robot
 const double DATA_LOSS_THRESHOLD = -2.0; // if stdn() is less than this, erase data

--- a/utils.cpp
+++ b/utils.cpp
@@ -31,7 +31,7 @@ trajectory_t transformTraj(const trajectory_t &traj, const transform_t &tf) {
 bool inRange(const point_t &p, const obstacle_t &obs) {
   point_t op;
   op << obs(0,0), obs(0,1), p(2);
-  return ((p-op).norm() < 2*NavSim::LIDAR_MAX_RANGE);
+  return ((p-op).norm() < 2*NavSim::OBSTACLE_MAX_SIZE);
 }
 
 bool collides(const transform_t &tf, const obstacles_t &obss)

--- a/world.cpp
+++ b/world.cpp
@@ -262,7 +262,7 @@ points_t World::readLidar() {
   points_t hits({});
   for(int j = 0; j < LIDAR_RESOLUTION; j++)
   {
-    double angle = j * 2 * M_PI / LIDAR_RESOLUTION;
+    double angle = LIDAR_FOV_DIR - (LIDAR_FOV / 2.0) + (j * LIDAR_FOV / LIDAR_RESOLUTION);
     point_t r0, r1;
     r0 << 0, 0, 1;
     r1 << LIDAR_MAX_RANGE*cos(angle), LIDAR_MAX_RANGE*sin(angle), 1;


### PR DESCRIPTION
Adjusted the lidar constants to limit the max lidar size

I had to create a new constant `OBSTACLE_MAX_SIZE` since the lidar max range was used for faster collision calculations, which broke if I decreased it.

I also added code to limit the lidar fov. (and center it at some angle)

The lidar spec sheets seems to say that it has a resolution of about ~682 scans, but that lags out the simulator so I left it at 100.